### PR TITLE
Linkit broken entity matcher deriver in Drupal 8.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -149,6 +149,9 @@
             },
             "drupal/google_analytics": {
                "Fatal error when there is a view with the path search/node":  "https://www.drupal.org/files/issues/2018-06-18/patch_google_analytics.patch"
+            },
+            "drupal/linkit": {
+                "Drupal 8.7 no longer has a dedicated canonical route for media entities, breaks entity matcher deriver - https://www.drupal.org/project/linkit/issues/3040749": "https://www.drupal.org/files/issues/2019-05-03/linkit-media-87-3040749-8.patch"
             }
         }
     },

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -81,6 +81,7 @@ projects[inline_entity_form][version] = 1.0-rc1
 projects[linked_field][type] = module
 projects[linked_field][version] = 1.1
 projects[linkit][type] = module
+projects[linkit][patch][] = https://www.drupal.org/files/issues/2019-05-03/linkit-media-87-3040749-8.patch
 projects[linkit][version] = 5.0-beta8
 projects[login_security][type] = module
 projects[login_security][version] = 1.5


### PR DESCRIPTION
This PR addresses patch from https://www.drupal.org/project/linkit/issues/3040749 and addresses the bundled Linkit module unable to match Media entities.